### PR TITLE
First steps for refactor: generators, vars, arrow funcs

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const updateFields = (ctx, func, data, err) => {
     ctx.log.error(e);
     return data;
   }
-}
+};
 
 /*
  * If logger is a bunyan logger instance, return it;
@@ -32,7 +32,7 @@ const createOrUseLogger = logger => {
   }
 
   return logger;
-}
+};
 
 /*
  * Koa middleware that adds this.log property to the koa context
@@ -46,7 +46,7 @@ const createOrUseLogger = logger => {
 module.exports = loggerInstance => {
   loggerInstance = createOrUseLogger(loggerInstance);
 
-  return logger = (ctx, next) => {
+  return (ctx, next) => {
     ctx.log = loggerInstance;
 
     return next();
@@ -76,7 +76,7 @@ module.exports.requestIdContext = opts => {
   const logField = opts.field || 'req_id';
   let fallbackLogger;
 
-  return requestIdContext = (ctx, next) => {
+  return (ctx, next) => {
     const reqId = ctx.request.get(header) || uuid.v4();
 
     ctx[ctxProp] = reqId;
@@ -136,7 +136,7 @@ module.exports.requestLogger = opts => {
                        this.status, data[durationField]);
   };
 
-  return requestLogger = (ctx, next) => {
+  return (ctx, next) => {
     const url = ctx.url;
     if (Array.isArray(opts.ignorePath) && opts.ignorePath.includes(ctx.path)) {
       return next();
@@ -212,7 +212,7 @@ module.exports.timeContext = opts => {
   const logLevel = opts.logLevel || 'trace';
   const updateLogFields = opts.updateLogFields;
 
-  return timeContext = (ctx, next) => {
+  return (ctx, next) => {
     ctx._timeContextStartTimes = {};
 
     ctx.time = time;

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,22 +194,6 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "co-mocha": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/co-mocha/-/co-mocha-1.2.2.tgz",
-      "integrity": "sha512-ocdJRn3sxonOqpdjSU2VwTwWzjTSoatzsTqCWiC3eGvJFNs8ZNMlZwfgYolQCdfddMz4muiZl99KIV9gKoNvxg==",
-      "dev": true,
-      "requires": {
-        "co": "^4.0.0",
-        "is-generator": "^1.0.1"
-      }
-    },
-    "co-supertest": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/co-supertest/-/co-supertest-0.0.10.tgz",
-      "integrity": "sha1-LNsoTouoA6CMN57P3h7o7sqPgzI=",
-      "dev": true
-    },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
@@ -842,12 +826,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "is-generator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
-      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=",
-      "dev": true
     },
     "is-generator-function": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
-    "co-mocha": "~1.2.2",
-    "co-supertest": "~0.0.10",
     "istanbul": "~0.4.0",
     "jshint": "^2.9.6",
     "koa": "^2.0.0",


### PR DESCRIPTION
## Motivation

fixes #24 

## Changes

- move from generators to async/await in tests
- stop using `var`, but `const` & `let` instead
- use of arrow functions